### PR TITLE
Cleanup lock file, support bearer token, remove interactive prompting

### DIFF
--- a/artifactory-docker-query.cljs
+++ b/artifactory-docker-query.cljs
@@ -33,7 +33,8 @@ Options:
                                       [env: ARTIFACTORY_BASE_URL]
   --artifactory-username USERNAME     Artifactory username
                                       [env: ARTIFACTORY_USERNAME]
-  --artifactory-identity-token TOKEN  Artifactory identity token
+  --artifactory-identity-token TOKEN  Artifactory identity token. If no username is
+                                      provided, then assume this is a bearer token.
                                       [env: ARTIFACTORY_IDENTITY_TOKEN]")
 
 (def IMAGE-SCHEMA
@@ -70,8 +71,6 @@ Options:
    _ (when debug
        (Epprint {:opts opts})
        (art/enable-debug))
-
-   opts (art/prompt-when-missing-credentials opts)
 
    auth-headers (art/get-auth-headers opts)
    opts (assoc opts

--- a/artifactory-npm-query.cljs
+++ b/artifactory-npm-query.cljs
@@ -33,7 +33,8 @@ Options:
                                       [env: ARTIFACTORY_BASE_URL]
   --artifactory-username USERNAME     Artifactory username
                                       [env: ARTIFACTORY_USERNAME]
-  --artifactory-identity-token TOKEN  Artifactory identity token
+  --artifactory-identity-token TOKEN  Artifactory identity token. If no username is
+                                      provided, then assume this is a bearer token.
                                       [env: ARTIFACTORY_IDENTITY_TOKEN]")
 
 (def MODULE-SCHEMA
@@ -56,8 +57,6 @@ Options:
    _ (when debug
        (Epprint {:opts opts})
        (art/enable-debug))
-
-   opts (art/prompt-when-missing-credentials opts)
 
    auth-headers (art/get-auth-headers opts)
    opts (assoc opts

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "dotenv": "^16.0.3",
         "fs-extra": "^11.0.0",
         "nbb": "^0.7.132",
-        "prompt": "^1.3.0",
         "xml2json": "^0.12.0"
       },
       "devDependencies": {
@@ -1608,14 +1607,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/@lonocloud/cljs-utils": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@lonocloud/cljs-utils/-/cljs-utils-0.1.3.tgz",
@@ -2916,11 +2907,6 @@
         "inherits": "2.0.3"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
-    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3267,14 +3253,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3403,14 +3381,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/data-view-buffer": {
@@ -3909,14 +3879,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
-    },
-    "node_modules/eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
-      "engines": {
-        "node": "> 0.1.90"
-      }
     },
     "node_modules/fast-xml-parser": {
       "version": "4.4.1",
@@ -4741,11 +4703,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
-    },
     "node_modules/iterate-iterator": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
@@ -4839,11 +4796,6 @@
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -4996,11 +4948,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "node_modules/nan": {
       "version": "2.22.2",
@@ -5340,21 +5287,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/prompt": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.3.0.tgz",
-      "integrity": "sha512-ZkaRWtaLBZl7KKAKndKYUL8WqNT+cQHKRZnT4RYYms48jQkFw3rrBL+/N5K/KtdEveHkxs982MX2BkDKub2ZMg==",
-      "dependencies": {
-        "@colors/colors": "1.5.0",
-        "async": "3.2.3",
-        "read": "1.0.x",
-        "revalidator": "0.1.x",
-        "winston": "2.x"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5462,17 +5394,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/read": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
-      "dependencies": {
-        "mute-stream": "~0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -5569,14 +5490,6 @@
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/revalidator": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
-      "integrity": "sha512-xcBILK2pA9oh4SiinPEZfhP8HfrB/ha+a2fTMyl7Om2WjlDVrOQy99N2MXXlUHqGJz4qEu2duXxHJjDWuK/0xg==",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/ripemd160": {
@@ -5908,14 +5821,6 @@
       "dev": true,
       "dependencies": {
         "source-map": "^0.5.6"
-      }
-    },
-    "node_modules/stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/statuses": {
@@ -6406,30 +6311,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/winston": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.7.tgz",
-      "integrity": "sha512-vLB4BqzCKDnnZH9PHGoS2ycawueX4HLqENXQitvFHczhgW2vFpSOn31LZtVr1KU8YTw7DS4tM+cqyovxo8taVg==",
-      "dependencies": {
-        "async": "^2.6.4",
-        "colors": "1.0.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "stack-trace": "0.0.x"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/winston/node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dependencies": {
-        "lodash": "^4.17.14"
       }
     },
     "node_modules/wrappy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,9 +45,8 @@
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
       "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
@@ -59,9 +58,8 @@
     },
     "node_modules/@aws-crypto/crc32c": {
       "version": "5.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
       "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
@@ -70,9 +68,8 @@
     },
     "node_modules/@aws-crypto/sha1-browser": {
       "version": "5.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
       "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/supports-web-crypto": "^5.2.0",
         "@aws-crypto/util": "^5.2.0",
@@ -84,9 +81,8 @@
     },
     "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -96,9 +92,8 @@
     },
     "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -109,9 +104,8 @@
     },
     "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -122,9 +116,8 @@
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-crypto/supports-web-crypto": "^5.2.0",
@@ -137,9 +130,8 @@
     },
     "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -149,9 +141,8 @@
     },
     "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -162,9 +153,8 @@
     },
     "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -175,9 +165,8 @@
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "5.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
@@ -189,18 +178,16 @@
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "5.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-crypto/util": {
       "version": "5.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-crypto/util/-/util-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
         "@smithy/util-utf8": "^2.0.0",
@@ -209,9 +196,8 @@
     },
     "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -221,9 +207,8 @@
     },
     "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -234,9 +219,8 @@
     },
     "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -246,18 +230,17 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudformation": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/client-cloudformation/-/client-cloudformation-3.758.0.tgz",
-      "integrity": "sha512-6P34tC0qXe2dmayFpXB1Jt3Izu75GxANYUJHj7aTnFMs/Gb8o1HBGrBeAKm10F00JPGBEPyqh3J9NHRJTB/s7Q==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.772.0.tgz",
+      "integrity": "sha512-ROgu3QlcfD3L/p1SBav7/2AxCh+SRmGF1QGVxv573ExXyE+G2GDeVdqYEpKgurvi2KSRJTXxygSW91ki6gFT3w==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/credential-provider-node": "3.772.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.772.0",
         "@aws-sdk/middleware-user-agent": "3.758.0",
         "@aws-sdk/region-config-resolver": "3.734.0",
         "@aws-sdk/types": "3.734.0",
@@ -299,18 +282,17 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.758.0.tgz",
-      "integrity": "sha512-IlEIm5h4vfeoZyY8Op4W6lX1lqcEYE3DRKl+fMKRTFttvJ+AJfuZlAgFlMh9OPFQ0ZMLe8etoxHwKN50YCLivw==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.772.0.tgz",
+      "integrity": "sha512-lbslpGJ7Yn9xHDFOGFnZQjmwVJb2S7TzYHqCnbSVu+vHzYmAWanVu+y8zc0sqcPb4ltS+KGtGdHYlmUJq2EqKg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/credential-provider-node": "3.772.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.772.0",
         "@aws-sdk/middleware-user-agent": "3.758.0",
         "@aws-sdk/region-config-resolver": "3.734.0",
         "@aws-sdk/types": "3.734.0",
@@ -354,18 +336,17 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.758.0.tgz",
-      "integrity": "sha512-8bOXVYtf/0OUN0jXTIHLv3V0TAS6kvvCRAy7nmiL/fDde0O+ChW1WZU7CVPAOtFEpFCdKskDcxFspM7m1k6qyg==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.772.0.tgz",
+      "integrity": "sha512-R11dYd2NGAH9TDRUJHd3Ab3HZzSoyqwQu+ZR9MZdcA2l3k99mqsrvcLp60YBPGq1dOEQDB1A85xgrAwtWLj81Q==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/credential-provider-node": "3.772.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.772.0",
         "@aws-sdk/middleware-user-agent": "3.758.0",
         "@aws-sdk/region-config-resolver": "3.734.0",
         "@aws-sdk/types": "3.734.0",
@@ -404,19 +385,18 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/client-dynamodb/-/client-dynamodb-3.758.0.tgz",
-      "integrity": "sha512-ZdVVCvmQ4wlV22HgYZKndIYNKkFfTLi8PIOF5rOkqthgYRTfVzKajrVbYebCs5jMDTk73LPLl2Ze/EYBEHKlBA==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.772.0.tgz",
+      "integrity": "sha512-MxUqb6vmWkZSR5UMuL7t5Bni22gwSZAweWdOEA9eXC/W4D7NIa8rMbsNl1lPvgF8OzIBvZBjkMzIHPuW/w4MrQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/credential-provider-node": "3.772.0",
         "@aws-sdk/middleware-endpoint-discovery": "3.734.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.772.0",
         "@aws-sdk/middleware-user-agent": "3.758.0",
         "@aws-sdk/region-config-resolver": "3.734.0",
         "@aws-sdk/types": "3.734.0",
@@ -458,18 +438,17 @@
       }
     },
     "node_modules/@aws-sdk/client-ec2": {
-      "version": "3.764.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/client-ec2/-/client-ec2-3.764.0.tgz",
-      "integrity": "sha512-EK3ptzIsNQ50efBxfVWEdLs2xTd3x5devvwPEO0HY19Au8py7VYtGOje/sXF8S0T7QQW3+Edu8t2KD+8ZnGkKA==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.772.0.tgz",
+      "integrity": "sha512-DCKMGcTGA0zdeRQIaUYr4QZfsRGB0W8NOz/cmLfXTMmCVY4b46mTui934aZixq1+PtLs5e4bPQ+VaLo1zt8MPg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/credential-provider-node": "3.772.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.772.0",
         "@aws-sdk/middleware-sdk-ec2": "3.758.0",
         "@aws-sdk/middleware-user-agent": "3.758.0",
         "@aws-sdk/region-config-resolver": "3.734.0",
@@ -512,18 +491,17 @@
       }
     },
     "node_modules/@aws-sdk/client-ecr": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/client-ecr/-/client-ecr-3.758.0.tgz",
-      "integrity": "sha512-9nTE01CuK5Vq0kPkmw3xdE6lrPDZSXOlX4wRc194GhnhxdppRla5dG6+gvZWTmpkC9a2mGqjXYsbvoSg6kZPHg==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.772.0.tgz",
+      "integrity": "sha512-vXT2H2VBa5u94sz9C8HRoRYAg24SuqXXE1Q715xyf9XWg2dc7vgO8bDFQIKqLpHfa6kmZ9CYvzf+BWusOOv2Iw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/credential-provider-node": "3.772.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.772.0",
         "@aws-sdk/middleware-user-agent": "3.758.0",
         "@aws-sdk/region-config-resolver": "3.734.0",
         "@aws-sdk/types": "3.734.0",
@@ -563,18 +541,17 @@
       }
     },
     "node_modules/@aws-sdk/client-iam": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/client-iam/-/client-iam-3.758.0.tgz",
-      "integrity": "sha512-tl+eH2t3ajUKd9a2l20B4X5foqlN2qiBIGXkGNPsL08rAc6tbQZlnnrp23aWURXqZZ/wqZP4StwyGk4s3QaxNQ==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.772.0.tgz",
+      "integrity": "sha512-VSo+agF3P3qq8sjf/FYst5W+gl0hRRwcteeBKPmgI2n6OysQcdiw7+z7IYfKPeKMzCmlN7i3c9K4p0dOR7vtbw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/credential-provider-node": "3.772.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.772.0",
         "@aws-sdk/middleware-user-agent": "3.758.0",
         "@aws-sdk/region-config-resolver": "3.734.0",
         "@aws-sdk/types": "3.734.0",
@@ -614,18 +591,17 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/client-lambda/-/client-lambda-3.758.0.tgz",
-      "integrity": "sha512-k7L9fe0NN1v2Vhg4ofA1pb26gTdGVFdkA6XUQyElLEdcKzJzoYiQ60faNLuMPfH0zsKNvy/xKfNOD6DFZWjgEg==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.772.0.tgz",
+      "integrity": "sha512-oe+EfCzLwSHY5d8J0eh0/DNhupMUyeLCLAQ+4RwlEbMkWESa2oyV9hNZ2n7+v0xE+qG9svQXLp3jW/hVM63ncA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/credential-provider-node": "3.772.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.772.0",
         "@aws-sdk/middleware-user-agent": "3.758.0",
         "@aws-sdk/region-config-resolver": "3.734.0",
         "@aws-sdk/types": "3.734.0",
@@ -669,18 +645,17 @@
       }
     },
     "node_modules/@aws-sdk/client-pricing": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/client-pricing/-/client-pricing-3.758.0.tgz",
-      "integrity": "sha512-omkdAtVHOZTLSXFY26b7oEPdbpIj3Ul03JXvyZd663YsRM6cXL+KcsfAunzFCOeU3GZLbJrnfCHCAv0Ff4b1mw==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-pricing/-/client-pricing-3.772.0.tgz",
+      "integrity": "sha512-wxsO/WPFAXQekrQQrVoXWZIzKh92On4gypfknDr1o91j9YZjlxapiLkc3tdWT4W5NrPb7wXOlbxq8kBKPRB8+A==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/credential-provider-node": "3.772.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.772.0",
         "@aws-sdk/middleware-user-agent": "3.758.0",
         "@aws-sdk/region-config-resolver": "3.734.0",
         "@aws-sdk/types": "3.734.0",
@@ -719,23 +694,22 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/client-s3/-/client-s3-3.758.0.tgz",
-      "integrity": "sha512-f8SlhU9/93OC/WEI6xVJf/x/GoQFj9a/xXK6QCtr5fvCjfSLgMVFmKTiIl/tgtDRzxUDc8YS6EGtbHjJ3Y/atg==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.772.0.tgz",
+      "integrity": "sha512-HQXlQIyyLp47h1/Hdjr36yK8/gsAAFX2vRzgDJhSRaz0vWZlWX07AJdYfrxapLUXfVU6DbBu3rwi2UGqM7ixqQ==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/credential-provider-node": "3.772.0",
         "@aws-sdk/middleware-bucket-endpoint": "3.734.0",
         "@aws-sdk/middleware-expect-continue": "3.734.0",
         "@aws-sdk/middleware-flexible-checksums": "3.758.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-location-constraint": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.772.0",
         "@aws-sdk/middleware-sdk-s3": "3.758.0",
         "@aws-sdk/middleware-ssec": "3.734.0",
         "@aws-sdk/middleware-user-agent": "3.758.0",
@@ -786,18 +760,17 @@
       }
     },
     "node_modules/@aws-sdk/client-service-catalog": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/client-service-catalog/-/client-service-catalog-3.758.0.tgz",
-      "integrity": "sha512-u6Zs56TEnBbpa8vpxhuTqsejYZ9JCnxgGKZmmGXQ6lAkbUwy5sNxkosBNAUVCQaYdmBu/aDlm73lvI11NTzmhg==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-service-catalog/-/client-service-catalog-3.772.0.tgz",
+      "integrity": "sha512-JmKF7CvCITC07cxgswwgGhHsU+e3icukiRQXLixLkTaAvIlQqrb4+/Da2hi1CQObgM3EW5w+UekGKw1cMpSjSw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/credential-provider-node": "3.772.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.772.0",
         "@aws-sdk/middleware-user-agent": "3.758.0",
         "@aws-sdk/region-config-resolver": "3.734.0",
         "@aws-sdk/types": "3.734.0",
@@ -838,18 +811,17 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.759.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/client-ssm/-/client-ssm-3.759.0.tgz",
-      "integrity": "sha512-+h1D1jBi6p2fG+ePxwIn2N4TOZcx7ExzhZJnpPT2actC9bV6vkRbeulGr/2fqNu11/S59DZJLfOHjVDH9X1nWA==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.772.0.tgz",
+      "integrity": "sha512-NPXybSztwGakQNonIHbMlwzTUaiHTSR+RsJnNrZkXpfp57Zny2zxcea8P/9OGQsCg3neUzRtoZxgPWb4jA9hLA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/credential-provider-node": "3.772.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.772.0",
         "@aws-sdk/middleware-user-agent": "3.758.0",
         "@aws-sdk/region-config-resolver": "3.734.0",
         "@aws-sdk/types": "3.734.0",
@@ -891,17 +863,16 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/client-sso/-/client-sso-3.758.0.tgz",
-      "integrity": "sha512-BoGO6IIWrLyLxQG6txJw6RT2urmbtlwfggapNCrNPyYjlXpzTSJhBYjndg7TpDATFd0SXL0zm8y/tXsUXNkdYQ==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.772.0.tgz",
+      "integrity": "sha512-sDdxepi74+cL6gXJJ2yw3UNSI7GBvoGTwZqFyPoNAzcURvaYwo8dBr7G4jS9GDanjTlO3CGVAf2VMcpqEvmoEw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.758.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.772.0",
         "@aws-sdk/middleware-user-agent": "3.758.0",
         "@aws-sdk/region-config-resolver": "3.734.0",
         "@aws-sdk/types": "3.734.0",
@@ -940,18 +911,17 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/client-sts/-/client-sts-3.758.0.tgz",
-      "integrity": "sha512-ue9hbzjWNQmmyoSeWDRPwnYddsD3BVao5mSFA1kXFNVqWPEenjpkZ1xAlBVzHMMNoEz7LvGI+onXIHntNyiOLQ==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.772.0.tgz",
+      "integrity": "sha512-L7lKpCMHrovfJPWv8lN3r+r2pywF3noVJVU3m353iY31jxSpRnwrfICPp3tc2Is91+0NDY2w/dZP+eW64+eRbw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/credential-provider-node": "3.772.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.772.0",
         "@aws-sdk/middleware-user-agent": "3.758.0",
         "@aws-sdk/region-config-resolver": "3.734.0",
         "@aws-sdk/types": "3.734.0",
@@ -991,9 +961,8 @@
     },
     "node_modules/@aws-sdk/core": {
       "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/core/-/core-3.758.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
       "integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@smithy/core": "^3.1.5",
@@ -1012,12 +981,11 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.758.0.tgz",
-      "integrity": "sha512-y/rHZqyChlEkNRr59gn4hv0gjhJwGmdCdW0JI1K9p3P9p7EurWGjr2M6+goTn3ilOlcAwrl5oFKR5jLt27TkOA==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.772.0.tgz",
+      "integrity": "sha512-rgGCB7+ttlOvuFjz016WVF0m1zDQNakreXVGmlqxKUHTgAkbXulbzcCnZt44S7QGP6V1ElbRB4jI7piRFirdwg==",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.758.0",
+        "@aws-sdk/client-cognito-identity": "3.772.0",
         "@aws-sdk/types": "3.734.0",
         "@smithy/property-provider": "^4.0.1",
         "@smithy/types": "^4.1.0",
@@ -1029,9 +997,8 @@
     },
     "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/credential-provider-env/-/credential-provider-env-3.758.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.758.0.tgz",
       "integrity": "sha512-N27eFoRrO6MeUNumtNHDW9WOiwfd59LPXPqDrIa3kWL/s+fOKFHb9xIcF++bAwtcZnAxKkgpDCUP+INNZskE+w==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "3.758.0",
         "@aws-sdk/types": "3.734.0",
@@ -1045,9 +1012,8 @@
     },
     "node_modules/@aws-sdk/credential-provider-http": {
       "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/credential-provider-http/-/credential-provider-http-3.758.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.758.0.tgz",
       "integrity": "sha512-Xt9/U8qUCiw1hihztWkNeIR+arg6P+yda10OuCHX6kFVx3auTlU7+hCqs3UxqniGU4dguHuftf3mRpi5/GJ33Q==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "3.758.0",
         "@aws-sdk/types": "3.734.0",
@@ -1065,18 +1031,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.758.0.tgz",
-      "integrity": "sha512-cymSKMcP5d+OsgetoIZ5QCe1wnp2Q/tq+uIxVdh9MbfdBBEnl9Ecq6dH6VlYS89sp4QKuxHxkWXVnbXU3Q19Aw==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.772.0.tgz",
+      "integrity": "sha512-T1Ec9Q25zl5c/eZUPHZsiq8vgBeWBjHM7WM5xtZszZRPqqhQGnmFlomz1r9rwhW8RFB5k8HRaD/SLKo6jtYl/A==",
       "dependencies": {
         "@aws-sdk/core": "3.758.0",
         "@aws-sdk/credential-provider-env": "3.758.0",
         "@aws-sdk/credential-provider-http": "3.758.0",
         "@aws-sdk/credential-provider-process": "3.758.0",
-        "@aws-sdk/credential-provider-sso": "3.758.0",
-        "@aws-sdk/credential-provider-web-identity": "3.758.0",
-        "@aws-sdk/nested-clients": "3.758.0",
+        "@aws-sdk/credential-provider-sso": "3.772.0",
+        "@aws-sdk/credential-provider-web-identity": "3.772.0",
+        "@aws-sdk/nested-clients": "3.772.0",
         "@aws-sdk/types": "3.734.0",
         "@smithy/credential-provider-imds": "^4.0.1",
         "@smithy/property-provider": "^4.0.1",
@@ -1089,17 +1054,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/credential-provider-node/-/credential-provider-node-3.758.0.tgz",
-      "integrity": "sha512-+DaMv63wiq7pJrhIQzZYMn4hSarKiizDoJRvyR7WGhnn0oQ/getX9Z0VNCV3i7lIFoLNTb7WMmQ9k7+z/uD5EQ==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.772.0.tgz",
+      "integrity": "sha512-0IdVfjBO88Mtekq/KaScYSIEPIeR+ABRvBOWyj/c/qQ2KJyI0GRlSAzpANfxDLHVPn3yEHuZd9nRL6sOmOMI0A==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.758.0",
         "@aws-sdk/credential-provider-http": "3.758.0",
-        "@aws-sdk/credential-provider-ini": "3.758.0",
+        "@aws-sdk/credential-provider-ini": "3.772.0",
         "@aws-sdk/credential-provider-process": "3.758.0",
-        "@aws-sdk/credential-provider-sso": "3.758.0",
-        "@aws-sdk/credential-provider-web-identity": "3.758.0",
+        "@aws-sdk/credential-provider-sso": "3.772.0",
+        "@aws-sdk/credential-provider-web-identity": "3.772.0",
         "@aws-sdk/types": "3.734.0",
         "@smithy/credential-provider-imds": "^4.0.1",
         "@smithy/property-provider": "^4.0.1",
@@ -1113,9 +1077,8 @@
     },
     "node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/credential-provider-process/-/credential-provider-process-3.758.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.758.0.tgz",
       "integrity": "sha512-AzcY74QTPqcbXWVgjpPZ3HOmxQZYPROIBz2YINF0OQk0MhezDWV/O7Xec+K1+MPGQO3qS6EDrUUlnPLjsqieHA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "3.758.0",
         "@aws-sdk/types": "3.734.0",
@@ -1129,14 +1092,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.758.0.tgz",
-      "integrity": "sha512-x0FYJqcOLUCv8GLLFDYMXRAQKGjoM+L0BG4BiHYZRDf24yQWFCAZsCQAYKo6XZYh2qznbsW6f//qpyJ5b0QVKQ==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.772.0.tgz",
+      "integrity": "sha512-yR3Y5RAVPa4ogojcBOpZUx6XyRVAkynIJCjd0avdlxW1hhnzSr5/pzoiJ6u21UCbkxlJJTDZE3jfFe7tt+HA4w==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.758.0",
+        "@aws-sdk/client-sso": "3.772.0",
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/token-providers": "3.758.0",
+        "@aws-sdk/token-providers": "3.772.0",
         "@aws-sdk/types": "3.734.0",
         "@smithy/property-provider": "^4.0.1",
         "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -1148,13 +1110,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.758.0.tgz",
-      "integrity": "sha512-XGguXhBqiCXMXRxcfCAVPlMbm3VyJTou79r/3mxWddHWF0XbhaQiBIbUz6vobVTD25YQRbWSmSch7VA8kI5Lrw==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.772.0.tgz",
+      "integrity": "sha512-yHAT5Y2y0fnecSuWRUn8NMunKfDqFYhnOpGq8UyCEcwz9aXzibU0hqRIEm51qpR81hqo0GMFDH0EOmegZ/iW5w==",
       "dependencies": {
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/nested-clients": "3.758.0",
+        "@aws-sdk/nested-clients": "3.772.0",
         "@aws-sdk/types": "3.734.0",
         "@smithy/property-provider": "^4.0.1",
         "@smithy/types": "^4.1.0",
@@ -1165,22 +1126,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/credential-providers/-/credential-providers-3.758.0.tgz",
-      "integrity": "sha512-BaGVBdm9ynsErIc/mLuUwJ1OQcL/pkhCuAm24jpsif3evZ5wgyZnEAZB2yRin+mQnQaQT3L+KvTbdKGfjL8+fQ==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.772.0.tgz",
+      "integrity": "sha512-+gOrzw05jNVSHFBTZ+LOaGQZ0IXT95aQjNUeWqYXzdgjxKXptrhuMnFLwBBliLbHPp8ziauRnnwG8aK58LOUlg==",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.758.0",
+        "@aws-sdk/client-cognito-identity": "3.772.0",
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.758.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.772.0",
         "@aws-sdk/credential-provider-env": "3.758.0",
         "@aws-sdk/credential-provider-http": "3.758.0",
-        "@aws-sdk/credential-provider-ini": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/credential-provider-ini": "3.772.0",
+        "@aws-sdk/credential-provider-node": "3.772.0",
         "@aws-sdk/credential-provider-process": "3.758.0",
-        "@aws-sdk/credential-provider-sso": "3.758.0",
-        "@aws-sdk/credential-provider-web-identity": "3.758.0",
-        "@aws-sdk/nested-clients": "3.758.0",
+        "@aws-sdk/credential-provider-sso": "3.772.0",
+        "@aws-sdk/credential-provider-web-identity": "3.772.0",
+        "@aws-sdk/nested-clients": "3.772.0",
         "@aws-sdk/types": "3.734.0",
         "@smithy/core": "^3.1.5",
         "@smithy/credential-provider-imds": "^4.0.1",
@@ -1194,9 +1154,8 @@
     },
     "node_modules/@aws-sdk/endpoint-cache": {
       "version": "3.723.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/endpoint-cache/-/endpoint-cache-3.723.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.723.0.tgz",
       "integrity": "sha512-2+a4WXRc+07uiPR+zJiPGKSOWaNJQNqitkks+6Hhm/haTLJqNVTgY2OWDh2PXvwMNpKB+AlGdhE65Oy6NzUgXg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "mnemonist": "0.38.3",
         "tslib": "^2.6.2"
@@ -1206,13 +1165,12 @@
       }
     },
     "node_modules/@aws-sdk/lib-dynamodb": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.758.0.tgz",
-      "integrity": "sha512-lkxh7nkFMHY2zbPxhGQz7hVA43yRPu+ERrSiRu7I11arAOz/MJlt7MjHmt0B8x7x6isF1utNixkU28HKh9hgWQ==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.772.0.tgz",
+      "integrity": "sha512-+ir8eClWxfkwrgYrgWCGh41EZ/07JPXJwvEmmhETzNDqvT/FaWLJC5rSKJW7o8nFxljW73lrwLreIO0oyBOsZw==",
       "dependencies": {
         "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/util-dynamodb": "3.758.0",
+        "@aws-sdk/util-dynamodb": "3.772.0",
         "@smithy/core": "^3.1.5",
         "@smithy/smithy-client": "^4.1.6",
         "@smithy/types": "^4.1.0",
@@ -1222,14 +1180,13 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.758.0"
+        "@aws-sdk/client-dynamodb": "^3.772.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
       "version": "3.734.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.734.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.734.0.tgz",
       "integrity": "sha512-etC7G18aF7KdZguW27GE/wpbrNmYLVT755EsFc8kXpZj8D6AFKxc7OuveinJmiy0bYXAMspJUWsF6CrGpOw6CQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@aws-sdk/util-arn-parser": "3.723.0",
@@ -1245,9 +1202,8 @@
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
       "version": "3.734.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.734.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.734.0.tgz",
       "integrity": "sha512-hE3x9Sbqy64g/lcFIq7BF9IS1tSOyfBCyHf1xBgevWeFIDTWh647URuCNWoEwtw4HMEhO2MDUQcKf1PFh1dNDA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/endpoint-cache": "3.723.0",
         "@aws-sdk/types": "3.734.0",
@@ -1262,9 +1218,8 @@
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
       "version": "3.734.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.734.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.734.0.tgz",
       "integrity": "sha512-P38/v1l6HjuB2aFUewt7ueAW5IvKkFcv5dalPtbMGRhLeyivBOHwbCyuRKgVs7z7ClTpu9EaViEGki2jEQqEsQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@smithy/protocol-http": "^5.0.1",
@@ -1277,9 +1232,8 @@
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
       "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.758.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.758.0.tgz",
       "integrity": "sha512-o8Rk71S08YTKLoSobucjnbj97OCGaXgpEDNKXpXaavUM5xLNoHCLSUPRCiEN86Ivqxg1n17Y2nSRhfbsveOXXA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
@@ -1301,9 +1255,8 @@
     },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.734.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
       "integrity": "sha512-LW7RRgSOHHBzWZnigNsDIzu3AiwtjeI2X66v+Wn1P1u+eXssy1+up4ZY/h+t2sU4LU36UvEf+jrZti9c6vRnFw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@smithy/protocol-http": "^5.0.1",
@@ -1316,9 +1269,8 @@
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
       "version": "3.734.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.734.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.734.0.tgz",
       "integrity": "sha512-EJEIXwCQhto/cBfHdm3ZOeLxd2NlJD+X2F+ZTOxzokuhBtY0IONfC/91hOo5tWQweerojwshSMHRCKzRv1tlwg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@smithy/types": "^4.1.0",
@@ -1330,9 +1282,8 @@
     },
     "node_modules/@aws-sdk/middleware-logger": {
       "version": "3.734.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
       "integrity": "sha512-mUMFITpJUW3LcKvFok176eI5zXAUomVtahb9IQBwLzkqFYOrMJvWAvoV4yuxrJ8TlQBG8gyEnkb9SnhZvjg67w==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@smithy/types": "^4.1.0",
@@ -1343,10 +1294,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.734.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz",
-      "integrity": "sha512-CUat2d9ITsFc2XsmeiRQO96iWpxSKYFjxvj27Hc7vo87YUHRnfMfnc8jw1EpxEwMcvBD7LsRa6vDNky6AjcrFA==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.772.0.tgz",
+      "integrity": "sha512-zg0LjJa4v7fcLzn5QzZvtVS+qyvmsnu7oQnb86l6ckduZpWDCDC9+A0ZzcXTrxblPCJd3JqkoG1+Gzi4S4Ny/Q==",
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@smithy/protocol-http": "^5.0.1",
@@ -1359,9 +1309,8 @@
     },
     "node_modules/@aws-sdk/middleware-sdk-ec2": {
       "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.758.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.758.0.tgz",
       "integrity": "sha512-5kx4pswtStytktl/yVhWO0MDKlYsW0awr+5LhqwBoJ5J6dFoVGp5uGAcSQz2PCvdT9PT/wBrGWWX+Lylb2HAGA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@aws-sdk/util-format-url": "3.734.0",
@@ -1378,9 +1327,8 @@
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
       "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.758.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.758.0.tgz",
       "integrity": "sha512-6mJ2zyyHPYSV6bAcaFpsdoXZJeQlR1QgBnZZ6juY/+dcYiuyWCdyLUbGzSZSE7GTfx6i+9+QWFeoIMlWKgU63A==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "3.758.0",
         "@aws-sdk/types": "3.734.0",
@@ -1403,9 +1351,8 @@
     },
     "node_modules/@aws-sdk/middleware-ssec": {
       "version": "3.734.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/middleware-ssec/-/middleware-ssec-3.734.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.734.0.tgz",
       "integrity": "sha512-d4yd1RrPW/sspEXizq2NSOUivnheac6LPeLSLnaeTbBG9g1KqIqvCzP1TfXEqv2CrWfHEsWtJpX7oyjySSPvDQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@smithy/types": "^4.1.0",
@@ -1417,9 +1364,8 @@
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.758.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.758.0.tgz",
       "integrity": "sha512-iNyehQXtQlj69JCgfaOssgZD4HeYGOwxcaKeG6F+40cwBjTAi0+Ph1yfDwqk2qiBPIRWJ/9l2LodZbxiBqgrwg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "3.758.0",
         "@aws-sdk/types": "3.734.0",
@@ -1434,17 +1380,16 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/nested-clients/-/nested-clients-3.758.0.tgz",
-      "integrity": "sha512-YZ5s7PSvyF3Mt2h1EQulCG93uybprNGbBkPmVuy/HMMfbFTt4iL3SbKjxqvOZelm86epFfj7pvK7FliI2WOEcg==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.772.0.tgz",
+      "integrity": "sha512-gNJbBxR5YlEumsCS9EWWEASXEnysL0aDnr9MNPX1ip/g1xOqRHmytgV/+t8RFZFTKg0OprbWTq5Ich3MqsEuCQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.758.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.772.0",
         "@aws-sdk/middleware-user-agent": "3.758.0",
         "@aws-sdk/region-config-resolver": "3.734.0",
         "@aws-sdk/types": "3.734.0",
@@ -1484,9 +1429,8 @@
     },
     "node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.734.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
       "integrity": "sha512-Lvj1kPRC5IuJBr9DyJ9T9/plkh+EfKLy+12s/mykOy1JaKHDpvj+XGy2YO6YgYVOb8JFtaqloid+5COtje4JTQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@smithy/node-config-provider": "^4.0.1",
@@ -1501,9 +1445,8 @@
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.758.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.758.0.tgz",
       "integrity": "sha512-0RPCo8fYJcrenJ6bRtiUbFOSgQ1CX/GpvwtLU2Fam1tS9h2klKK8d74caeV6A1mIUvBU7bhyQ0wMGlwMtn3EYw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/middleware-sdk-s3": "3.758.0",
         "@aws-sdk/types": "3.734.0",
@@ -1517,12 +1460,11 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/token-providers/-/token-providers-3.758.0.tgz",
-      "integrity": "sha512-ckptN1tNrIfQUaGWm/ayW1ddG+imbKN7HHhjFdS4VfItsP0QQOB0+Ov+tpgb4MoNR4JaUghMIVStjIeHN2ks1w==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.772.0.tgz",
+      "integrity": "sha512-d1Waa1vyebuokcAWYlkZdtFlciIgob7B39vPRmtxMObbGumJKiOy/qCe2/FB/72h1Ej9Ih32lwvbxUjORQWN4g==",
       "dependencies": {
-        "@aws-sdk/nested-clients": "3.758.0",
+        "@aws-sdk/nested-clients": "3.772.0",
         "@aws-sdk/types": "3.734.0",
         "@smithy/property-provider": "^4.0.1",
         "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -1535,9 +1477,8 @@
     },
     "node_modules/@aws-sdk/types": {
       "version": "3.734.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/types/-/types-3.734.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
       "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
@@ -1548,9 +1489,8 @@
     },
     "node_modules/@aws-sdk/util-arn-parser": {
       "version": "3.723.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/util-arn-parser/-/util-arn-parser-3.723.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.723.0.tgz",
       "integrity": "sha512-ZhEfvUwNliOQROcAk34WJWVYTlTa4694kSVhDSjW6lE1bMataPnIN8A0ycukEzBXmd8ZSoBcQLn6lKGl7XIJ5w==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -1559,10 +1499,9 @@
       }
     },
     "node_modules/@aws-sdk/util-dynamodb": {
-      "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/util-dynamodb/-/util-dynamodb-3.758.0.tgz",
-      "integrity": "sha512-JjBbhJLajilyMWJ/z82bYgIMj9XGISZ/QMYSpNBdzGFRmL1AL9s6NwLB6FuquRvpY9Lo3Y5vwEbedqdZPIrRFg==",
-      "license": "Apache-2.0",
+      "version": "3.772.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.772.0.tgz",
+      "integrity": "sha512-joFi/d2BJir7jCWKYe26CqBSbC5B0FZ33UmF9K+ft5tGPvpPkdDpfkqAXD/t+NN/119TbxfSpkLehnI8VowXZg==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -1570,14 +1509,13 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.758.0"
+        "@aws-sdk/client-dynamodb": "^3.772.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
       "version": "3.743.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
       "integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@smithy/types": "^4.1.0",
@@ -1590,9 +1528,8 @@
     },
     "node_modules/@aws-sdk/util-format-url": {
       "version": "3.734.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/util-format-url/-/util-format-url-3.734.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.734.0.tgz",
       "integrity": "sha512-TxZMVm8V4aR/QkW9/NhujvYpPZjUYqzLwSge5imKZbWFR806NP7RMwc5ilVuHF/bMOln/cVHkl42kATElWBvNw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@smithy/querystring-builder": "^4.0.1",
@@ -1605,9 +1542,8 @@
     },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.723.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/util-locate-window/-/util-locate-window-3.723.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.723.0.tgz",
       "integrity": "sha512-Yf2CS10BqK688DRsrKI/EO6B8ff5J86NXe4C+VCysK7UOgN0l1zOTeTukZ3H8Q9tYYX3oaF1961o8vRkFm7Nmw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -1617,9 +1553,8 @@
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.734.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
       "integrity": "sha512-xQTCus6Q9LwUuALW+S76OL0jcWtMOVu14q+GoLnWPUM7QeUw963oQcLhF7oq0CtaLLKyl4GOUfcwc773Zmwwng==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@smithy/types": "^4.1.0",
@@ -1629,9 +1564,8 @@
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.758.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.758.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.758.0.tgz",
       "integrity": "sha512-A5EZw85V6WhoKMV2hbuFRvb9NPlxEErb4HPO6/SPXYY4QrjprIzScHxikqcWv1w4J3apB1wto9LPU3IMsYtfrw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/middleware-user-agent": "3.758.0",
         "@aws-sdk/types": "3.734.0",
@@ -1653,9 +1587,8 @@
     },
     "node_modules/@aws-sdk/xml-builder": {
       "version": "3.734.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@aws-sdk/xml-builder/-/xml-builder-3.734.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.734.0.tgz",
       "integrity": "sha512-Zrjxi5qwGEcUsJ0ru7fRtW74WcTS0rbLcehoFB+rN1GRi2hbLcFaYs4PwVA5diLeAJH0gszv3x4Hr/S87MfbKQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
@@ -1665,10 +1598,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
-      "license": "MIT",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1678,18 +1610,16 @@
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@colors/colors/-/colors-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
       }
     },
     "node_modules/@lonocloud/cljs-utils": {
       "version": "0.1.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@lonocloud/cljs-utils/-/cljs-utils-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@lonocloud/cljs-utils/-/cljs-utils-0.1.3.tgz",
       "integrity": "sha512-Eu5pbqUOlTtHEUuoP04JSD/LDr7N/WpYjo0TavrPVGCwMLDzYbOFBFMbavDBZUOHaLc00a8THza/mHG8DpqzKg==",
-      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "easy-table": "1.2.0",
         "nbb": "^0.7.132",
@@ -1699,18 +1629,16 @@
     },
     "node_modules/@octokit/auth-token": {
       "version": "3.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
       "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
-      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/@octokit/core": {
       "version": "4.2.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@octokit/core/-/core-4.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
       "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
-      "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -1726,9 +1654,8 @@
     },
     "node_modules/@octokit/endpoint": {
       "version": "7.0.6",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
       "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
-      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^9.0.0",
         "is-plain-object": "^5.0.0",
@@ -1740,9 +1667,8 @@
     },
     "node_modules/@octokit/graphql": {
       "version": "5.0.6",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@octokit/graphql/-/graphql-5.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
       "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
-      "license": "MIT",
       "dependencies": {
         "@octokit/request": "^6.0.0",
         "@octokit/types": "^9.0.0",
@@ -1754,15 +1680,13 @@
     },
     "node_modules/@octokit/openapi-types": {
       "version": "18.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
-      "integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
+      "integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw=="
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "6.1.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
       "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
-      "license": "MIT",
       "dependencies": {
         "@octokit/tsconfig": "^1.0.2",
         "@octokit/types": "^9.2.3"
@@ -1776,18 +1700,16 @@
     },
     "node_modules/@octokit/plugin-request-log": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "license": "MIT",
       "peerDependencies": {
         "@octokit/core": ">=3"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
       "version": "7.2.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
       "integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
-      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^10.0.0"
       },
@@ -1800,18 +1722,16 @@
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
       "version": "10.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@octokit/types/-/types-10.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
       "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
-      "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/request": {
       "version": "6.2.8",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@octokit/request/-/request-6.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
       "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
-      "license": "MIT",
       "dependencies": {
         "@octokit/endpoint": "^7.0.0",
         "@octokit/request-error": "^3.0.0",
@@ -1826,9 +1746,8 @@
     },
     "node_modules/@octokit/request-error": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@octokit/request-error/-/request-error-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
       "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
-      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^9.0.0",
         "deprecation": "^2.0.0",
@@ -1840,9 +1759,8 @@
     },
     "node_modules/@octokit/rest": {
       "version": "19.0.13",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@octokit/rest/-/rest-19.0.13.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.13.tgz",
       "integrity": "sha512-/EzVox5V9gYGdbAI+ovYj3nXQT1TtTHRT+0eZPcuC05UFSWO3mdO9UY1C0i2eLF9Un1ONJkAk+IEtYGAC+TahA==",
-      "license": "MIT",
       "dependencies": {
         "@octokit/core": "^4.2.1",
         "@octokit/plugin-paginate-rest": "^6.1.2",
@@ -1855,24 +1773,21 @@
     },
     "node_modules/@octokit/tsconfig": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA=="
     },
     "node_modules/@octokit/types": {
       "version": "9.3.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@octokit/types/-/types-9.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
       "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@slack/bolt": {
       "version": "3.22.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@slack/bolt/-/bolt-3.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-3.22.0.tgz",
       "integrity": "sha512-iKDqGPEJDnrVwxSVlFW6OKTkijd7s4qLBeSufoBsTM0reTyfdp/5izIQVkxNfzjHi3o6qjdYbRXkYad5HBsBog==",
-      "license": "MIT",
       "dependencies": {
         "@slack/logger": "^4.0.0",
         "@slack/oauth": "^2.6.3",
@@ -1895,10 +1810,9 @@
       }
     },
     "node_modules/@slack/bolt/node_modules/axios": {
-      "version": "1.8.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/axios/-/axios-1.8.2.tgz",
-      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
-      "license": "MIT",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -1907,9 +1821,8 @@
     },
     "node_modules/@slack/bolt/node_modules/form-data": {
       "version": "4.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/form-data/-/form-data-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
       "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -1922,9 +1835,8 @@
     },
     "node_modules/@slack/logger": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@slack/logger/-/logger-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
       "integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": ">=18.0.0"
       },
@@ -1935,9 +1847,8 @@
     },
     "node_modules/@slack/oauth": {
       "version": "2.6.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@slack/oauth/-/oauth-2.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/@slack/oauth/-/oauth-2.6.3.tgz",
       "integrity": "sha512-1amXs6xRkJpoH6zSgjVPgGEJXCibKNff9WNDijcejIuVy1HFAl1adh7lehaGNiHhTWfQkfKxBiF+BGn56kvoFw==",
-      "license": "MIT",
       "dependencies": {
         "@slack/logger": "^3.0.0",
         "@slack/web-api": "^6.12.1",
@@ -1953,9 +1864,8 @@
     },
     "node_modules/@slack/oauth/node_modules/@slack/logger": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@slack/logger/-/logger-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
       "integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": ">=12.0.0"
       },
@@ -1966,9 +1876,8 @@
     },
     "node_modules/@slack/socket-mode": {
       "version": "1.3.6",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@slack/socket-mode/-/socket-mode-1.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-1.3.6.tgz",
       "integrity": "sha512-G+im7OP7jVqHhiNSdHgv2VVrnN5U7KY845/5EZimZkrD4ZmtV0P3BiWkgeJhPtdLuM7C7i6+M6h6Bh+S4OOalA==",
-      "license": "MIT",
       "dependencies": {
         "@slack/logger": "^3.0.0",
         "@slack/web-api": "^6.12.1",
@@ -1985,9 +1894,8 @@
     },
     "node_modules/@slack/socket-mode/node_modules/@slack/logger": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@slack/logger/-/logger-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
       "integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": ">=12.0.0"
       },
@@ -1998,9 +1906,8 @@
     },
     "node_modules/@slack/types": {
       "version": "2.14.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@slack/types/-/types-2.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.14.0.tgz",
       "integrity": "sha512-n0EGm7ENQRxlXbgKSrQZL69grzg1gHLAVd+GlRVQJ1NSORo0FrApR7wql/gaKdu2n4TO83Sq/AmeUOqD60aXUA==",
-      "license": "MIT",
       "engines": {
         "node": ">= 12.13.0",
         "npm": ">= 6.12.0"
@@ -2008,9 +1915,8 @@
     },
     "node_modules/@slack/web-api": {
       "version": "6.13.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@slack/web-api/-/web-api-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.13.0.tgz",
       "integrity": "sha512-dv65crIgdh9ZYHrevLU6XFHTQwTyDmNqEqzuIrV+Vqe/vgiG6w37oex5ePDU1RGm2IJ90H8iOvHFvzdEO/vB+g==",
-      "license": "MIT",
       "dependencies": {
         "@slack/logger": "^3.0.0",
         "@slack/types": "^2.11.0",
@@ -2031,9 +1937,8 @@
     },
     "node_modules/@slack/web-api/node_modules/@slack/logger": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@slack/logger/-/logger-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
       "integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": ">=12.0.0"
       },
@@ -2043,10 +1948,9 @@
       }
     },
     "node_modules/@slack/web-api/node_modules/axios": {
-      "version": "1.8.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/axios/-/axios-1.8.2.tgz",
-      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
-      "license": "MIT",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -2055,9 +1959,8 @@
     },
     "node_modules/@slack/web-api/node_modules/axios/node_modules/form-data": {
       "version": "4.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/form-data/-/form-data-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
       "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -2070,15 +1973,13 @@
     },
     "node_modules/@slack/web-api/node_modules/eventemitter3": {
       "version": "3.1.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
       "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
@@ -2089,9 +1990,8 @@
     },
     "node_modules/@smithy/chunked-blob-reader": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.0.0.tgz",
       "integrity": "sha512-+sKqDBQqb036hh4NPaUiEkYFkTUGYzRsn3EuFhyfQfMy6oGHEUJDurLP9Ufb5dasr/XiAmPNMr6wa9afjQB+Gw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2101,9 +2001,8 @@
     },
     "node_modules/@smithy/chunked-blob-reader-native": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.0.0.tgz",
       "integrity": "sha512-R9wM2yPmfEMsUmlMlIgSzOyICs0x9uu7UTHoccMyt7BWw8shcGM8HqB355+BZCPBcySvbTYMs62EgEQkNxz2ig==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-base64": "^4.0.0",
         "tslib": "^2.6.2"
@@ -2114,9 +2013,8 @@
     },
     "node_modules/@smithy/config-resolver": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
       "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.0.1",
         "@smithy/types": "^4.1.0",
@@ -2130,9 +2028,8 @@
     },
     "node_modules/@smithy/core": {
       "version": "3.1.5",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/core/-/core-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
       "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^4.0.2",
         "@smithy/protocol-http": "^5.0.1",
@@ -2149,9 +2046,8 @@
     },
     "node_modules/@smithy/credential-provider-imds": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
       "integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.0.1",
         "@smithy/property-provider": "^4.0.1",
@@ -2165,9 +2061,8 @@
     },
     "node_modules/@smithy/eventstream-codec": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/eventstream-codec/-/eventstream-codec-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.1.tgz",
       "integrity": "sha512-Q2bCAAR6zXNVtJgifsU16ZjKGqdw/DyecKNgIgi7dlqw04fqDu0mnq+JmGphqheypVc64CYq3azSuCpAdFk2+A==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@smithy/types": "^4.1.0",
@@ -2180,9 +2075,8 @@
     },
     "node_modules/@smithy/eventstream-serde-browser": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.1.tgz",
       "integrity": "sha512-HbIybmz5rhNg+zxKiyVAnvdM3vkzjE6ccrJ620iPL8IXcJEntd3hnBl+ktMwIy12Te/kyrSbUb8UCdnUT4QEdA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/eventstream-serde-universal": "^4.0.1",
         "@smithy/types": "^4.1.0",
@@ -2194,9 +2088,8 @@
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.0.1.tgz",
       "integrity": "sha512-lSipaiq3rmHguHa3QFF4YcCM3VJOrY9oq2sow3qlhFY+nBSTF/nrO82MUQRPrxHQXA58J5G1UnU2WuJfi465BA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
@@ -2207,9 +2100,8 @@
     },
     "node_modules/@smithy/eventstream-serde-node": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.1.tgz",
       "integrity": "sha512-o4CoOI6oYGYJ4zXo34U8X9szDe3oGjmHgsMGiZM0j4vtNoT+h80TLnkUcrLZR3+E6HIxqW+G+9WHAVfl0GXK0Q==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/eventstream-serde-universal": "^4.0.1",
         "@smithy/types": "^4.1.0",
@@ -2221,9 +2113,8 @@
     },
     "node_modules/@smithy/eventstream-serde-universal": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.1.tgz",
       "integrity": "sha512-Z94uZp0tGJuxds3iEAZBqGU2QiaBHP4YytLUjwZWx+oUeohCsLyUm33yp4MMBmhkuPqSbQCXq5hDet6JGUgHWA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/eventstream-codec": "^4.0.1",
         "@smithy/types": "^4.1.0",
@@ -2235,9 +2126,8 @@
     },
     "node_modules/@smithy/fetch-http-handler": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
       "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.0.1",
         "@smithy/querystring-builder": "^4.0.1",
@@ -2251,9 +2141,8 @@
     },
     "node_modules/@smithy/hash-blob-browser": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/hash-blob-browser/-/hash-blob-browser-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.0.1.tgz",
       "integrity": "sha512-rkFIrQOKZGS6i1D3gKJ8skJ0RlXqDvb1IyAphksaFOMzkn3v3I1eJ8m7OkLj0jf1McP63rcCEoLlkAn/HjcTRw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/chunked-blob-reader": "^5.0.0",
         "@smithy/chunked-blob-reader-native": "^4.0.0",
@@ -2266,9 +2155,8 @@
     },
     "node_modules/@smithy/hash-node": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/hash-node/-/hash-node-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
       "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "@smithy/util-buffer-from": "^4.0.0",
@@ -2281,9 +2169,8 @@
     },
     "node_modules/@smithy/hash-stream-node": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/hash-stream-node/-/hash-stream-node-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.0.1.tgz",
       "integrity": "sha512-U1rAE1fxmReCIr6D2o/4ROqAQX+GffZpyMt3d7njtGDr2pUNmAKRWa49gsNVhCh2vVAuf3wXzWwNr2YN8PAXIw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "@smithy/util-utf8": "^4.0.0",
@@ -2295,9 +2182,8 @@
     },
     "node_modules/@smithy/invalid-dependency": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
       "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
@@ -2308,9 +2194,8 @@
     },
     "node_modules/@smithy/is-array-buffer": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
       "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2320,9 +2205,8 @@
     },
     "node_modules/@smithy/md5-js": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/md5-js/-/md5-js-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.0.1.tgz",
       "integrity": "sha512-HLZ647L27APi6zXkZlzSFZIjpo8po45YiyjMGJZM3gyDY8n7dPGdmxIIljLm4gPt/7rRvutLTTkYJpZVfG5r+A==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "@smithy/util-utf8": "^4.0.0",
@@ -2334,9 +2218,8 @@
     },
     "node_modules/@smithy/middleware-content-length": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
       "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.0.1",
         "@smithy/types": "^4.1.0",
@@ -2348,9 +2231,8 @@
     },
     "node_modules/@smithy/middleware-endpoint": {
       "version": "4.0.6",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
       "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.1.5",
         "@smithy/middleware-serde": "^4.0.2",
@@ -2367,9 +2249,8 @@
     },
     "node_modules/@smithy/middleware-retry": {
       "version": "4.0.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
       "integrity": "sha512-58j9XbUPLkqAcV1kHzVX/kAR16GT+j7DUZJqwzsxh1jtz7G82caZiGyyFgUvogVfNTg3TeAOIJepGc8TXF4AVQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.0.1",
         "@smithy/protocol-http": "^5.0.1",
@@ -2387,9 +2268,8 @@
     },
     "node_modules/@smithy/middleware-serde": {
       "version": "4.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
       "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
@@ -2400,9 +2280,8 @@
     },
     "node_modules/@smithy/middleware-stack": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
       "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
@@ -2413,9 +2292,8 @@
     },
     "node_modules/@smithy/node-config-provider": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
       "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.1",
         "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -2428,9 +2306,8 @@
     },
     "node_modules/@smithy/node-http-handler": {
       "version": "4.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
       "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^4.0.1",
         "@smithy/protocol-http": "^5.0.1",
@@ -2444,9 +2321,8 @@
     },
     "node_modules/@smithy/property-provider": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
       "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
@@ -2457,9 +2333,8 @@
     },
     "node_modules/@smithy/protocol-http": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
       "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
@@ -2470,9 +2345,8 @@
     },
     "node_modules/@smithy/querystring-builder": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
       "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "@smithy/util-uri-escape": "^4.0.0",
@@ -2484,9 +2358,8 @@
     },
     "node_modules/@smithy/querystring-parser": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
       "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
@@ -2497,9 +2370,8 @@
     },
     "node_modules/@smithy/service-error-classification": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
       "integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0"
       },
@@ -2509,9 +2381,8 @@
     },
     "node_modules/@smithy/shared-ini-file-loader": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
       "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
@@ -2522,9 +2393,8 @@
     },
     "node_modules/@smithy/signature-v4": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
       "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
         "@smithy/protocol-http": "^5.0.1",
@@ -2541,9 +2411,8 @@
     },
     "node_modules/@smithy/smithy-client": {
       "version": "4.1.6",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
       "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.1.5",
         "@smithy/middleware-endpoint": "^4.0.6",
@@ -2559,9 +2428,8 @@
     },
     "node_modules/@smithy/types": {
       "version": "4.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/types/-/types-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
       "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2571,9 +2439,8 @@
     },
     "node_modules/@smithy/url-parser": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
       "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/querystring-parser": "^4.0.1",
         "@smithy/types": "^4.1.0",
@@ -2585,9 +2452,8 @@
     },
     "node_modules/@smithy/util-base64": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
       "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
         "@smithy/util-utf8": "^4.0.0",
@@ -2599,9 +2465,8 @@
     },
     "node_modules/@smithy/util-body-length-browser": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
       "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2611,9 +2476,8 @@
     },
     "node_modules/@smithy/util-body-length-node": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
       "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2623,9 +2487,8 @@
     },
     "node_modules/@smithy/util-buffer-from": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
       "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
         "tslib": "^2.6.2"
@@ -2636,9 +2499,8 @@
     },
     "node_modules/@smithy/util-config-provider": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
       "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2648,9 +2510,8 @@
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
       "version": "4.0.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
       "integrity": "sha512-CZgDDrYHLv0RUElOsmZtAnp1pIjwDVCSuZWOPhIOBvG36RDfX1Q9+6lS61xBf+qqvHoqRjHxgINeQz47cYFC2Q==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.1",
         "@smithy/smithy-client": "^4.1.6",
@@ -2664,9 +2525,8 @@
     },
     "node_modules/@smithy/util-defaults-mode-node": {
       "version": "4.0.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
       "integrity": "sha512-79fQW3hnfCdrfIi1soPbK3zmooRFnLpSx3Vxi6nUlqaaQeC5dm8plt4OTNDNqEEEDkvKghZSaoti684dQFVrGQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.0.1",
         "@smithy/credential-provider-imds": "^4.0.1",
@@ -2682,9 +2542,8 @@
     },
     "node_modules/@smithy/util-endpoints": {
       "version": "3.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
       "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.0.1",
         "@smithy/types": "^4.1.0",
@@ -2696,9 +2555,8 @@
     },
     "node_modules/@smithy/util-hex-encoding": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
       "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2708,9 +2566,8 @@
     },
     "node_modules/@smithy/util-middleware": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
       "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
@@ -2721,9 +2578,8 @@
     },
     "node_modules/@smithy/util-retry": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-retry/-/util-retry-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
       "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/service-error-classification": "^4.0.1",
         "@smithy/types": "^4.1.0",
@@ -2735,9 +2591,8 @@
     },
     "node_modules/@smithy/util-stream": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-stream/-/util-stream-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.2.tgz",
       "integrity": "sha512-44PKEqQ303d3rlQuiDpcCcu//hV8sn+u2JBo84dWCE0rvgeiVl0IlLMagbU++o0jCWhYCsHaAt9wZuZqNe05Hw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.0.1",
         "@smithy/node-http-handler": "^4.0.3",
@@ -2754,9 +2609,8 @@
     },
     "node_modules/@smithy/util-uri-escape": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
       "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2766,9 +2620,8 @@
     },
     "node_modules/@smithy/util-utf8": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
       "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
         "tslib": "^2.6.2"
@@ -2779,9 +2632,8 @@
     },
     "node_modules/@smithy/util-waiter": {
       "version": "4.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@smithy/util-waiter/-/util-waiter-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.2.tgz",
       "integrity": "sha512-piUTHyp2Axx3p/kc2CIJkYSv0BAaheBQmbACZgQSSfWUumWNW+R1lL+H9PDBxKJkvOeEX+hKYEFiwO8xagL8AQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^4.0.1",
         "@smithy/types": "^4.1.0",
@@ -2793,9 +2645,8 @@
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
       "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -2803,27 +2654,24 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/connect/-/connect-3.4.38.tgz",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/debug/-/debug-4.1.12.tgz",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
-      "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
       }
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/express/-/express-4.17.21.tgz",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
       "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -2833,9 +2681,8 @@
     },
     "node_modules/@types/express-serve-static-core": {
       "version": "4.19.6",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
       "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -2845,78 +2692,67 @@
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "node_modules/@types/is-stream": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "8.5.9",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
       "integrity": "sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/ms/-/ms-2.1.0.tgz",
-      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
-      "version": "22.13.9",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/node/-/node-22.13.9.tgz",
-      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
-      "license": "MIT",
+      "version": "22.13.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.11.tgz",
+      "integrity": "sha512-iEUCUJoU0i3VnrCmgoWCXttklWcvoCIx4jzcP22fioIVSdTmjgoEvmAO/QPw6TcS9k5FrNgn4w7q5lGOd1CT5g==",
       "dependencies": {
         "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/promise.allsettled": {
       "version": "1.0.6",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/promise.allsettled/-/promise.allsettled-1.0.6.tgz",
-      "integrity": "sha512-wA0UT0HeT2fGHzIFV9kWpYz5mdoyLxKrTgMdZQM++5h6pYAFH73HXcQhefg24nD1yivUFEn5KU+EF4b+CXJ4Wg==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/promise.allsettled/-/promise.allsettled-1.0.6.tgz",
+      "integrity": "sha512-wA0UT0HeT2fGHzIFV9kWpYz5mdoyLxKrTgMdZQM++5h6pYAFH73HXcQhefg24nD1yivUFEn5KU+EF4b+CXJ4Wg=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.18",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/qs/-/qs-6.9.18.tgz",
-      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/send/-/send-0.17.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -2924,9 +2760,8 @@
     },
     "node_modules/@types/serve-static": {
       "version": "1.15.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
       "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*",
@@ -2935,30 +2770,26 @@
     },
     "node_modules/@types/tsscmp": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/tsscmp/-/tsscmp-1.0.2.tgz",
-      "integrity": "sha512-cy7BRSU8GYYgxjcx0Py+8lo5MthuDhlyu076KUcYzVNXL23luYgRHkMG2fIFEc6neckeh/ntP82mw+U4QjZq+g==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/tsscmp/-/tsscmp-1.0.2.tgz",
+      "integrity": "sha512-cy7BRSU8GYYgxjcx0Py+8lo5MthuDhlyu076KUcYzVNXL23luYgRHkMG2fIFEc6neckeh/ntP82mw+U4QjZq+g=="
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/@types/ws/-/ws-7.4.7.tgz",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
       "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/accepts/-/accepts-1.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -2969,27 +2800,24 @@
     },
     "node_modules/adm-zip": {
       "version": "0.5.16",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/adm-zip/-/adm-zip-0.5.16.tgz",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
       "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=12.0"
       }
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
       "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "is-array-buffer": "^3.0.5"
@@ -3003,15 +2831,13 @@
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
     "node_modules/array.prototype.map": {
       "version": "1.0.8",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/array.prototype.map/-/array.prototype.map-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.8.tgz",
       "integrity": "sha512-YocPM7bYYu2hXGxWpb5vwZ8cMeudNHYtYBcUDY4Z1GWa53qcnQMWSl25jeBHNzitjl9HW2AWW4ro/S/nftUaOQ==",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -3030,9 +2856,8 @@
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
       "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
-      "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
         "call-bind": "^1.0.8",
@@ -3051,10 +2876,9 @@
     },
     "node_modules/asn1.js": {
       "version": "4.10.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/asn1.js/-/asn1.js-4.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -3063,17 +2887,15 @@
     },
     "node_modules/asn1.js/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/bn.js/-/bn.js-4.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
       "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/assert": {
       "version": "1.5.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/assert/-/assert-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.1.tgz",
       "integrity": "sha512-zzw1uCAgLbsKwBfFc8CX78DDg+xZeBksSO3vwVIDDN5i94eOrPsSSyiVhmsSABFDM/OcpE2aagCat9dnWQLG1A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "object.assign": "^4.1.4",
         "util": "^0.10.4"
@@ -3081,47 +2903,41 @@
     },
     "node_modules/assert/node_modules/inherits": {
       "version": "2.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/inherits/-/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/assert/node_modules/util": {
       "version": "0.10.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/util/-/util-0.10.4.tgz",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
       "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "inherits": "2.0.3"
       }
     },
     "node_modules/async": {
       "version": "3.2.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/async/-/async-3.2.3.tgz",
-      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "node_modules/async-function": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/async-function/-/async-function-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
       "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -3134,9 +2950,8 @@
     },
     "node_modules/axios": {
       "version": "0.27.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/axios/-/axios-0.27.2.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
       "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
@@ -3144,9 +2959,8 @@
     },
     "node_modules/axios-debug-log": {
       "version": "0.8.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/axios-debug-log/-/axios-debug-log-0.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/axios-debug-log/-/axios-debug-log-0.8.4.tgz",
       "integrity": "sha512-DvmaJiYusndhfAjQ94HqlvhaVoEjOetwo9cpb+OVtOZNZTqdz0VAVed3ZjSQKpyM1g8jDXUXFx0Pg1DhUZzAdw==",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0"
@@ -3159,7 +2973,6 @@
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
       "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "is-retry-allowed": "^2.2.0"
@@ -3167,9 +2980,8 @@
     },
     "node_modules/axios/node_modules/form-data": {
       "version": "4.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/form-data/-/form-data-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
       "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3182,7 +2994,7 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/base64-js/-/base64-js-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true,
       "funding": [
@@ -3198,36 +3010,31 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/before-after-hook/-/before-after-hook-2.2.3.tgz",
-      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
     "node_modules/bindings": {
       "version": "1.5.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/bindings/-/bindings-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/bn.js/-/bn.js-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/body-parser/-/body-parser-1.20.3.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
       "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -3249,38 +3056,33 @@
     },
     "node_modules/body-parser/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/bowser": {
       "version": "2.11.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brorand": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/brorand/-/brorand-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -3292,10 +3094,9 @@
     },
     "node_modules/browserify-cipher": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "browserify-aes": "^1.0.4",
         "browserify-des": "^1.0.0",
@@ -3304,10 +3105,9 @@
     },
     "node_modules/browserify-des": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/browserify-des/-/browserify-des-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
@@ -3317,10 +3117,9 @@
     },
     "node_modules/browserify-rsa": {
       "version": "4.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
       "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bn.js": "^5.2.1",
         "randombytes": "^2.1.0",
@@ -3332,10 +3131,9 @@
     },
     "node_modules/browserify-sign": {
       "version": "4.2.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/browserify-sign/-/browserify-sign-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
       "integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "bn.js": "^5.2.1",
         "browserify-rsa": "^4.1.0",
@@ -3354,20 +3152,18 @@
     },
     "node_modules/browserify-zlib": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "pako": "~1.0.5"
       }
     },
     "node_modules/buffer": {
       "version": "4.9.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/buffer/-/buffer-4.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -3376,45 +3172,39 @@
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/buffer/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/bytes/-/bytes-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/call-bind/-/call-bind-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
@@ -3430,9 +3220,8 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -3443,9 +3232,8 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/call-bound/-/call-bound-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -3459,10 +3247,9 @@
     },
     "node_modules/cipher-base": {
       "version": "1.0.6",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/cipher-base/-/cipher-base-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
       "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
         "safe-buffer": "^5.2.1"
@@ -3473,9 +3260,8 @@
     },
     "node_modules/clone": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/clone/-/clone-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.8"
@@ -3483,18 +3269,16 @@
     },
     "node_modules/colors": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/colors/-/colors-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
       }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3504,22 +3288,20 @@
     },
     "node_modules/console-browserify": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/console-browserify/-/console-browserify-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
     },
     "node_modules/constants-browserify": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/content-disposition/-/content-disposition-0.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -3529,41 +3311,36 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/content-type/-/content-type-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie": {
       "version": "0.7.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/cookie/-/cookie-0.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/core-util-is/-/core-util-is-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
       "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.5.3"
@@ -3571,17 +3348,15 @@
     },
     "node_modules/create-ecdh/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/bn.js/-/bn.js-4.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
       "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -3592,10 +3367,9 @@
     },
     "node_modules/create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -3607,10 +3381,9 @@
     },
     "node_modules/crypto-browserify": {
       "version": "3.12.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
       "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "browserify-cipher": "^1.0.1",
         "browserify-sign": "^4.2.3",
@@ -3634,7 +3407,7 @@
     },
     "node_modules/cycle": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/cycle/-/cycle-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "integrity": "sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==",
       "engines": {
         "node": ">=0.4.0"
@@ -3642,9 +3415,8 @@
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
       "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
@@ -3659,9 +3431,8 @@
     },
     "node_modules/data-view-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
       "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
@@ -3676,9 +3447,8 @@
     },
     "node_modules/data-view-byte-offset": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
       "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -3693,9 +3463,8 @@
     },
     "node_modules/debug": {
       "version": "4.4.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/debug/-/debug-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3710,9 +3479,8 @@
     },
     "node_modules/defaults": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/defaults/-/defaults-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "clone": "^1.0.2"
@@ -3723,9 +3491,8 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/define-data-property/-/define-data-property-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -3740,9 +3507,8 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/define-properties/-/define-properties-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -3757,34 +3523,30 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/depd/-/depd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/deprecation": {
       "version": "2.3.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/deprecation/-/deprecation-2.3.1.tgz",
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "node_modules/des.js": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/des.js/-/des.js-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
       "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
@@ -3792,9 +3554,8 @@
     },
     "node_modules/destroy": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/destroy/-/destroy-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -3802,10 +3563,9 @@
     },
     "node_modules/diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
@@ -3814,17 +3574,15 @@
     },
     "node_modules/diffie-hellman/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/bn.js/-/bn.js-4.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
       "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/domain-browser": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/domain-browser/-/domain-browser-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.4",
         "npm": ">=1.2"
@@ -3832,9 +3590,8 @@
     },
     "node_modules/dotenv": {
       "version": "16.4.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/dotenv/-/dotenv-16.4.7.tgz",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
       "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -3844,9 +3601,8 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -3858,9 +3614,8 @@
     },
     "node_modules/easy-table": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/easy-table/-/easy-table-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.2.0.tgz",
       "integrity": "sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==",
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -3870,25 +3625,22 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/elliptic": {
       "version": "6.6.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/elliptic/-/elliptic-6.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
       "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -3901,25 +3653,22 @@
     },
     "node_modules/elliptic/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/bn.js/-/bn.js-4.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
       "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/encodeurl/-/encodeurl-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/es-abstract": {
       "version": "1.23.9",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/es-abstract/-/es-abstract-1.23.9.tgz",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
       "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
-      "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.2",
         "arraybuffer.prototype.slice": "^1.0.4",
@@ -3982,33 +3731,29 @@
     },
     "node_modules/es-array-method-boxes-properly": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-get-iterator": {
       "version": "1.1.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
       "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -4026,9 +3771,8 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -4038,9 +3782,8 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -4053,9 +3796,8 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
       "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
-      "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7",
         "is-date-object": "^1.0.5",
@@ -4070,41 +3812,36 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/events/-/events-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
       }
     },
     "node_modules/evp_bytestokey": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -4112,9 +3849,8 @@
     },
     "node_modules/express": {
       "version": "4.21.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/express/-/express-4.21.2.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
-      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4158,28 +3894,25 @@
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/express/node_modules/path-to-regexp": {
       "version": "0.1.12",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/eyes": {
       "version": "0.1.8",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/eyes/-/eyes-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
       "engines": {
         "node": "> 0.1.90"
@@ -4187,7 +3920,7 @@
     },
     "node_modules/fast-xml-parser": {
       "version": "4.4.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
       "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
       "funding": [
         {
@@ -4199,7 +3932,6 @@
           "url": "https://paypal.me/naturalintelligence"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "strnum": "^1.0.5"
       },
@@ -4209,15 +3941,13 @@
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/finalhandler": {
       "version": "1.3.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/finalhandler/-/finalhandler-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
       "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
-      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
@@ -4233,28 +3963,25 @@
     },
     "node_modules/finalhandler/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/finity": {
       "version": "0.5.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/finity/-/finity-0.5.4.tgz",
-      "integrity": "sha512-3l+5/1tuw616Lgb0QBimxfdd2TqaDGpfCBpfX6EqtFmqUV3FtQnVEX4Aa62DagYEqnsTIjZcTfbq9msDbXYgyA==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/finity/-/finity-0.5.4.tgz",
+      "integrity": "sha512-3l+5/1tuw616Lgb0QBimxfdd2TqaDGpfCBpfX6EqtFmqUV3FtQnVEX4Aa62DagYEqnsTIjZcTfbq9msDbXYgyA=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
       "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
@@ -4262,7 +3989,6 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -4274,9 +4000,8 @@
     },
     "node_modules/for-each": {
       "version": "0.3.5",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/for-each/-/for-each-0.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
       },
@@ -4289,9 +4014,8 @@
     },
     "node_modules/form-data": {
       "version": "2.5.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/form-data/-/form-data-2.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
       "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
-      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -4305,27 +4029,24 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/forwarded/-/forwarded-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/fresh": {
       "version": "0.5.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/fs-extra": {
       "version": "11.3.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/fs-extra/-/fs-extra-11.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
       "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -4337,18 +4058,16 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.8",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
       "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -4366,18 +4085,16 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -4399,9 +4116,8 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -4412,9 +4128,8 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
       "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
@@ -4429,9 +4144,8 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/globalthis/-/globalthis-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -4445,9 +4159,8 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4457,15 +4170,13 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/has-bigints/-/has-bigints-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
       "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4475,9 +4186,8 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -4487,9 +4197,8 @@
     },
     "node_modules/has-proto": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/has-proto/-/has-proto-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
       "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
-      "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.0"
       },
@@ -4502,9 +4211,8 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4514,9 +4222,8 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -4529,10 +4236,9 @@
     },
     "node_modules/hash-base": {
       "version": "3.0.5",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/hash-base/-/hash-base-3.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
       "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
         "safe-buffer": "^5.2.1"
@@ -4543,10 +4249,9 @@
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/hash.js/-/hash.js-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -4554,9 +4259,8 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/hasown/-/hasown-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -4566,10 +4270,9 @@
     },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -4578,19 +4281,17 @@
     },
     "node_modules/hoek": {
       "version": "4.3.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/hoek/-/hoek-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.3.1.tgz",
       "integrity": "sha512-v7E+yIjcHECn973i0xHm4kJkEpv3C8sbYS4344WXbzYqRyiDD7rjnnKo4hsJkejQBAFdRMUGNHySeSPKSH9Rqw==",
       "deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "license": "SEE LICENSE IN LICENSE.md",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/http-errors/-/http-errors-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -4604,16 +4305,14 @@
     },
     "node_modules/https-browserify": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/https-browserify/-/https-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -4623,7 +4322,7 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/ieee754/-/ieee754-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true,
       "funding": [
@@ -4639,14 +4338,12 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "BSD-3-Clause"
+      ]
     },
     "node_modules/import-meta-resolve": {
       "version": "2.2.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz",
       "integrity": "sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -4654,15 +4351,13 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/internal-slot/-/internal-slot-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "hasown": "^2.0.2",
@@ -4674,18 +4369,16 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-arguments/-/is-arguments-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
       "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -4699,9 +4392,8 @@
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
       "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -4716,9 +4408,8 @@
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-async-function/-/is-async-function-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
       "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
-      "license": "MIT",
       "dependencies": {
         "async-function": "^1.0.0",
         "call-bound": "^1.0.3",
@@ -4735,9 +4426,8 @@
     },
     "node_modules/is-bigint": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-bigint/-/is-bigint-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
       "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
-      "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.2"
       },
@@ -4750,9 +4440,8 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
       "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
@@ -4766,9 +4455,8 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-callable/-/is-callable-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4778,9 +4466,8 @@
     },
     "node_modules/is-data-view": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-data-view/-/is-data-view-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
       "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "get-intrinsic": "^1.2.6",
@@ -4795,9 +4482,8 @@
     },
     "node_modules/is-date-object": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-date-object/-/is-date-object-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -4811,15 +4497,13 @@
     },
     "node_modules/is-electron": {
       "version": "2.2.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-electron/-/is-electron-2.2.2.tgz",
-      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
     },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
       "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
       },
@@ -4832,9 +4516,8 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
       "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "get-proto": "^1.0.0",
@@ -4850,9 +4533,8 @@
     },
     "node_modules/is-map": {
       "version": "2.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-map/-/is-map-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4862,9 +4544,8 @@
     },
     "node_modules/is-number-object": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-number-object/-/is-number-object-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
       "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
@@ -4878,18 +4559,16 @@
     },
     "node_modules/is-plain-object": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-regex/-/is-regex-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "gopd": "^1.2.0",
@@ -4907,7 +4586,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
       "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4917,9 +4595,8 @@
     },
     "node_modules/is-set": {
       "version": "2.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-set/-/is-set-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4929,9 +4606,8 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
       "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
       },
@@ -4944,18 +4620,16 @@
     },
     "node_modules/is-stream": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/is-string": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-string/-/is-string-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
       "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
@@ -4969,9 +4643,8 @@
     },
     "node_modules/is-symbol": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-symbol/-/is-symbol-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
       "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-symbols": "^1.1.0",
@@ -4986,9 +4659,8 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
       },
@@ -5001,9 +4673,8 @@
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5013,9 +4684,8 @@
     },
     "node_modules/is-weakref": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-weakref/-/is-weakref-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
       "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
       },
@@ -5028,9 +4698,8 @@
     },
     "node_modules/is-weakset": {
       "version": "2.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/is-weakset/-/is-weakset-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
       "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "get-intrinsic": "^1.2.6"
@@ -5044,15 +4713,13 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/isemail": {
       "version": "3.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/isemail/-/isemail-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
       "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "punycode": "2.x.x"
       },
@@ -5062,40 +4729,35 @@
     },
     "node_modules/isemail/node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/punycode/-/punycode-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/isstream": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "node_modules/iterate-iterator": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
       "integrity": "sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==",
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/iterate-value": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/iterate-value/-/iterate-value-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
       "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
-      "license": "MIT",
       "dependencies": {
         "es-get-iterator": "^1.0.2",
         "iterate-iterator": "^1.0.1"
@@ -5106,10 +4768,9 @@
     },
     "node_modules/joi": {
       "version": "13.7.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/joi/-/joi-13.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
       "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
       "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "hoek": "5.x.x",
         "isemail": "3.x.x",
@@ -5121,19 +4782,17 @@
     },
     "node_modules/joi/node_modules/hoek": {
       "version": "5.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/hoek/-/hoek-5.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
       "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
       "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8.9.0"
       }
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/jsonfile/-/jsonfile-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -5143,9 +4802,8 @@
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
       "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-      "license": "MIT",
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -5165,9 +4823,8 @@
     },
     "node_modules/jwa": {
       "version": "1.4.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/jwa/-/jwa-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
       "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -5176,9 +4833,8 @@
     },
     "node_modules/jws": {
       "version": "3.2.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/jws/-/jws-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "license": "MIT",
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -5186,67 +4842,57 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/md5.js/-/md5.js-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -5255,37 +4901,33 @@
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/methods": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
@@ -5296,16 +4938,14 @@
     },
     "node_modules/miller-rabin/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/bn.js/-/bn.js-4.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
       "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/mime": {
       "version": "1.6.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/mime/-/mime-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -5315,18 +4955,16 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -5336,50 +4974,43 @@
     },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/mnemonist": {
       "version": "0.38.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/mnemonist/-/mnemonist-0.38.3.tgz",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
-      "license": "MIT",
       "dependencies": {
         "obliterator": "^1.6.1"
       }
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "node_modules/nan": {
       "version": "2.22.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/nan/-/nan-2.22.2.tgz",
-      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ=="
     },
     "node_modules/nbb": {
       "version": "0.7.135",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/nbb/-/nbb-0.7.135.tgz",
+      "resolved": "https://registry.npmjs.org/nbb/-/nbb-0.7.135.tgz",
       "integrity": "sha512-mojt/az9RWSV3CAzMLq64fD4MmXjmnHdEuC7E1fIpQa8M3sRUlKAMSOXTBebiy5Yg9M1WffHGWr8IwUZF9Qg3w==",
-      "license": "EPL-1.0",
       "dependencies": {
         "import-meta-resolve": "^2.1.0"
       },
@@ -5389,37 +5020,33 @@
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/negotiator/-/negotiator-0.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/neodoc": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/neodoc/-/neodoc-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/neodoc/-/neodoc-2.0.2.tgz",
       "integrity": "sha512-NAppJ0YecKWdhSXFYCHbo6RutiX8vOt/Jo3l46mUg6pQlpJNaqc5cGxdrW2jITQm5JIYySbFVPDl3RrREXNyPw==",
-      "license": "LicenseRef-LICENSE",
       "dependencies": {
         "ansi-regex": "^2.0.0"
       }
     },
     "node_modules/neodoc/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/node-expat": {
       "version": "2.4.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/node-expat/-/node-expat-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.4.1.tgz",
       "integrity": "sha512-uWgvQLgo883NKIL+66oJsK9ysKK3ej0YjVCPBZzO/7wMAuH68/Yb7+JwPWNaVq0yPaxrb48AoEXfYEc8gsmFbg==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "nan": "^2.19.0"
@@ -5427,9 +5054,8 @@
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/node-fetch/-/node-fetch-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -5447,10 +5073,9 @@
     },
     "node_modules/node-libs-browser": {
       "version": "2.2.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
       "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "assert": "^1.1.1",
         "browserify-zlib": "^0.2.0",
@@ -5479,9 +5104,8 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/object-inspect/-/object-inspect-1.13.4.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5491,18 +5115,16 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.assign": {
       "version": "4.1.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/object.assign/-/object.assign-4.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -5520,15 +5142,13 @@
     },
     "node_modules/obliterator": {
       "version": "1.6.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/obliterator/-/obliterator-1.6.1.tgz",
-      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/on-finished/-/on-finished-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -5538,25 +5158,22 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/os-browserify": {
       "version": "0.3.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/os-browserify/-/os-browserify-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/own-keys/-/own-keys-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
       "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
-      "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.6",
         "object-keys": "^1.1.1",
@@ -5571,18 +5188,16 @@
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/p-finally/-/p-finally-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/p-queue": {
       "version": "6.6.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/p-queue/-/p-queue-6.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
       "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
-      "license": "MIT",
       "dependencies": {
         "eventemitter3": "^4.0.4",
         "p-timeout": "^3.2.0"
@@ -5596,15 +5211,13 @@
     },
     "node_modules/p-queue/node_modules/eventemitter3": {
       "version": "4.0.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/p-retry": {
       "version": "4.6.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/p-retry/-/p-retry-4.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
       "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "license": "MIT",
       "dependencies": {
         "@types/retry": "0.12.0",
         "retry": "^0.13.1"
@@ -5615,9 +5228,8 @@
     },
     "node_modules/p-timeout": {
       "version": "3.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/p-timeout/-/p-timeout-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "license": "MIT",
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -5627,17 +5239,15 @@
     },
     "node_modules/pako": {
       "version": "1.0.11",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/pako/-/pako-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true,
-      "license": "(MIT AND Zlib)"
+      "dev": true
     },
     "node_modules/parse-asn1": {
       "version": "5.1.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/parse-asn1/-/parse-asn1-5.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
       "integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "asn1.js": "^4.10.1",
         "browserify-aes": "^1.2.0",
@@ -5652,35 +5262,31 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/parseurl/-/parseurl-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/path-browserify": {
       "version": "0.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/path-browserify/-/path-browserify-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
       "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/path-to-regexp": {
       "version": "8.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
       "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/pbkdf2": {
       "version": "3.1.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
       "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -5694,35 +5300,31 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/process": {
       "version": "0.11.10",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/process/-/process-0.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/promise.allsettled": {
       "version": "1.0.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/promise.allsettled/-/promise.allsettled-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.7.tgz",
       "integrity": "sha512-hezvKvQQmsFkOdrZfYxUxkyxl8mgFQeT259Ajj9PXdbg9VzBCWrItOev72JyWxkCD5VSSqAeHmlN3tWx4DlmsA==",
-      "license": "MIT",
       "dependencies": {
         "array.prototype.map": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -5740,9 +5342,8 @@
     },
     "node_modules/prompt": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/prompt/-/prompt-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.3.0.tgz",
       "integrity": "sha512-ZkaRWtaLBZl7KKAKndKYUL8WqNT+cQHKRZnT4RYYms48jQkFw3rrBL+/N5K/KtdEveHkxs982MX2BkDKub2ZMg==",
-      "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.5.0",
         "async": "3.2.3",
@@ -5756,9 +5357,8 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -5769,16 +5369,14 @@
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
       "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.1.0",
         "browserify-rsa": "^4.0.0",
@@ -5790,23 +5388,20 @@
     },
     "node_modules/public-encrypt/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/bn.js/-/bn.js-4.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
       "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/punycode": {
       "version": "1.4.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/punycode/-/punycode-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/qs": {
       "version": "6.13.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/qs/-/qs-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
       "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -5819,7 +5414,7 @@
     },
     "node_modules/querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
       "dev": true,
       "engines": {
@@ -5828,20 +5423,18 @@
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/randombytes/-/randombytes-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/randomfill": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/randomfill/-/randomfill-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
@@ -5849,18 +5442,16 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/range-parser/-/range-parser-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/raw-body": {
       "version": "2.5.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/raw-body/-/raw-body-2.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
       "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -5873,9 +5464,8 @@
     },
     "node_modules/read": {
       "version": "1.0.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/read/-/read-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
-      "license": "ISC",
       "dependencies": {
         "mute-stream": "~0.0.4"
       },
@@ -5885,10 +5475,9 @@
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/readable-stream/-/readable-stream-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -5901,43 +5490,38 @@
     },
     "node_modules/readable-stream/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/readable-stream/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/readline-sync": {
       "version": "1.4.10",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/readline-sync/-/readline-sync-1.4.10.tgz",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
       "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
       "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
@@ -5958,14 +5542,12 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
@@ -5983,28 +5565,25 @@
     },
     "node_modules/retry": {
       "version": "0.13.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/retry/-/retry-0.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/revalidator": {
       "version": "0.1.8",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/revalidator/-/revalidator-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
       "integrity": "sha512-xcBILK2pA9oh4SiinPEZfhP8HfrB/ha+a2fTMyl7Om2WjlDVrOQy99N2MXXlUHqGJz4qEu2duXxHJjDWuK/0xg==",
-      "license": "Apache 2.0",
       "engines": {
         "node": ">= 0.4.0"
       }
     },
     "node_modules/ripemd160": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/ripemd160/-/ripemd160-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -6012,9 +5591,8 @@
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
       "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.2",
@@ -6031,7 +5609,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
@@ -6046,14 +5624,12 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
       "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "isarray": "^2.0.5"
@@ -6067,9 +5643,8 @@
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -6084,15 +5659,13 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
       "version": "7.7.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/semver/-/semver-7.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6102,9 +5675,8 @@
     },
     "node_modules/send": {
       "version": "0.19.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/send/-/send-0.19.0.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
       "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
-      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -6126,33 +5698,29 @@
     },
     "node_modules/send/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/send/node_modules/encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/serve-static": {
       "version": "1.16.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/serve-static/-/serve-static-1.16.2.tgz",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
       "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
-      "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
@@ -6165,9 +5733,8 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/set-function-length/-/set-function-length-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -6182,9 +5749,8 @@
     },
     "node_modules/set-function-name": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/set-function-name/-/set-function-name-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -6197,9 +5763,8 @@
     },
     "node_modules/set-proto": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/set-proto/-/set-proto-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
       "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
-      "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -6211,23 +5776,20 @@
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/setimmediate/-/setimmediate-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
-      "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -6238,10 +5800,9 @@
     },
     "node_modules/shadow-cljs": {
       "version": "2.20.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/shadow-cljs/-/shadow-cljs-2.20.2.tgz",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.2.tgz",
       "integrity": "sha512-2kzWnV1QM6KBetziCAkCf8BJdnDX2CwiAr4yhvOsiQpaNJcMzwMsJTX/gTHz58yQg0dV5uwPsIyBlvyIfl30rg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "node-libs-browser": "^2.2.1",
         "readline-sync": "^1.4.7",
@@ -6259,16 +5820,14 @@
     },
     "node_modules/shadow-cljs-jar": {
       "version": "1.3.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz",
       "integrity": "sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/side-channel/-/side-channel-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -6285,9 +5844,8 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -6301,9 +5859,8 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -6319,9 +5876,8 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -6338,47 +5894,42 @@
     },
     "node_modules/source-map": {
       "version": "0.5.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-support": {
       "version": "0.4.18",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/source-map-support/-/source-map-support-0.4.18.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "source-map": "^0.5.6"
       }
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/stack-trace/-/stack-trace-0.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/statuses": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/statuses/-/statuses-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
       "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "internal-slot": "^1.1.0"
@@ -6389,10 +5940,9 @@
     },
     "node_modules/stream-browserify": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
       "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
@@ -6400,10 +5950,9 @@
     },
     "node_modules/stream-http": {
       "version": "2.8.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/stream-http/-/stream-http-2.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "builtin-status-codes": "^3.0.0",
         "inherits": "^2.0.1",
@@ -6414,19 +5963,17 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/string_decoder/-/string_decoder-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
       "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.2",
@@ -6445,9 +5992,8 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.9",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
       "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.2",
@@ -6463,9 +6009,8 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.8",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -6480,22 +6025,20 @@
     },
     "node_modules/strnum": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/strnum/-/strnum-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
       "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/timers-browserify/-/timers-browserify-2.0.12.tgz",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
       "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "setimmediate": "^1.0.4"
       },
@@ -6505,70 +6048,61 @@
     },
     "node_modules/to-arraybuffer": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/toidentifier/-/toidentifier-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
     },
     "node_modules/topo": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/topo/-/topo-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
       "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
       "deprecated": "This module has moved and is now available at @hapi/topo. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "hoek": "6.x.x"
       }
     },
     "node_modules/topo/node_modules/hoek": {
       "version": "6.1.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/hoek/-/hoek-6.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
       "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
-      "deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "license": "BSD-3-Clause"
+      "deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues."
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/tsscmp/-/tsscmp-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.6.x"
       }
     },
     "node_modules/tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/type-is": {
       "version": "1.6.18",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/type-is/-/type-is-1.6.18.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -6579,9 +6113,8 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
@@ -6593,9 +6126,8 @@
     },
     "node_modules/typed-array-byte-length": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
       "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
@@ -6612,9 +6144,8 @@
     },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
       "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
-      "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
@@ -6633,9 +6164,8 @@
     },
     "node_modules/typed-array-length": {
       "version": "1.0.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
       "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -6653,9 +6183,8 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
       "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "has-bigints": "^1.0.2",
@@ -6671,40 +6200,35 @@
     },
     "node_modules/undici-types": {
       "version": "6.20.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
     },
     "node_modules/universalify": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/universalify/-/universalify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/url": {
       "version": "0.11.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/url/-/url-0.11.4.tgz",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
       "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "punycode": "^1.4.1",
         "qs": "^6.12.3"
@@ -6715,71 +6239,63 @@
     },
     "node_modules/util": {
       "version": "0.11.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/util/-/util-0.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
       "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "inherits": "2.0.3"
       }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/util/node_modules/inherits": {
       "version": "2.0.3",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/inherits/-/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
     },
     "node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/uuid/-/uuid-9.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/wcwidth/-/wcwidth-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "defaults": "^1.0.3"
@@ -6787,15 +6303,13 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -6803,10 +6317,9 @@
     },
     "node_modules/which": {
       "version": "1.3.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/which/-/which-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -6816,9 +6329,8 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
       "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
-      "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.1.0",
         "is-boolean-object": "^1.2.1",
@@ -6835,9 +6347,8 @@
     },
     "node_modules/which-builtin-type": {
       "version": "1.2.1",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
       "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "function.prototype.name": "^1.1.6",
@@ -6862,9 +6373,8 @@
     },
     "node_modules/which-collection": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/which-collection/-/which-collection-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-      "license": "MIT",
       "dependencies": {
         "is-map": "^2.0.3",
         "is-set": "^2.0.3",
@@ -6879,15 +6389,15 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.18",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/which-typed-array/-/which-typed-array-1.1.18.tgz",
-      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
-      "license": "MIT",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "for-each": "^0.3.3",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
@@ -6900,9 +6410,8 @@
     },
     "node_modules/winston": {
       "version": "2.4.7",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/winston/-/winston-2.4.7.tgz",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.7.tgz",
       "integrity": "sha512-vLB4BqzCKDnnZH9PHGoS2ycawueX4HLqENXQitvFHczhgW2vFpSOn31LZtVr1KU8YTw7DS4tM+cqyovxo8taVg==",
-      "license": "MIT",
       "dependencies": {
         "async": "^2.6.4",
         "colors": "1.0.x",
@@ -6917,24 +6426,21 @@
     },
     "node_modules/winston/node_modules/async": {
       "version": "2.6.4",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/async/-/async-2.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
       "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
       }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
       "version": "7.5.10",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/ws/-/ws-7.5.10.tgz",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -6953,9 +6459,8 @@
     },
     "node_modules/xml2json": {
       "version": "0.12.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/xml2json/-/xml2json-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/xml2json/-/xml2json-0.12.0.tgz",
       "integrity": "sha512-EPJHRWJnJUYbJlzR4pBhZODwWdi2IaYGtDdteJi0JpZ4OD31IplWALuit8r73dJuM4iHZdDVKY1tLqY2UICejg==",
-      "license": "MIT",
       "dependencies": {
         "hoek": "^4.2.1",
         "joi": "^13.1.2",
@@ -6967,19 +6472,17 @@
     },
     "node_modules/xtend": {
       "version": "4.0.2",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/xtend/-/xtend-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.4"
       }
     },
     "node_modules/yaml": {
       "version": "2.7.0",
-      "resolved": "https://artifactory.viasat.com:443/artifactory/api/npm/npmjs-remote/yaml/-/yaml-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
       "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "dotenv": "^16.0.3",
     "fs-extra": "^11.0.0",
     "nbb": "^0.7.132",
-    "prompt": "^1.3.0",
     "xml2json": "^0.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Lock file contained internal resolutions. Use standard npmjs.org locations.

If token is set but username is not then assume this is a bearer token rather than basic auth and use it thusly.

Remove the interactive prompting. It's a weird flow and it complicates bearer token logic and was probably a mistake anyways (pretty sure I'm originally responsible for that). @jonsmock If actually still using interactive prompting, I can probably figure out how to put it back and still work with bearer tokens. But if not, it's probably just overhead to keep this feature around.