### PR TITLE
Replace xml2json with fast-xml-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,9 @@
         "axios-retry": "^3.9.1",
         "debug": "^4.4.0",
         "dotenv": "^16.0.3",
+        "fast-xml-parser": "^4.5.3",
         "fs-extra": "^11.0.0",
-        "nbb": "^0.7.132",
-        "xml2json": "^0.12.0"
+        "nbb": "^0.7.132"
       },
       "devDependencies": {
         "shadow-cljs": "2.20.2"
@@ -977,6 +977,28 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
@@ -3003,14 +3025,6 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "node_modules/bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
@@ -3881,30 +3895,22 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^1.1.1"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/finalhandler": {
       "version": "1.3.1",
@@ -4239,15 +4245,6 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "node_modules/hoek": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.3.1.tgz",
-      "integrity": "sha512-v7E+yIjcHECn973i0xHm4kJkEpv3C8sbYS4344WXbzYqRyiDD7rjnnKo4hsJkejQBAFdRMUGNHySeSPKSH9Rqw==",
-      "deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/http-errors": {
@@ -4678,25 +4675,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
-    "node_modules/isemail": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-      "dependencies": {
-        "punycode": "2.x.x"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/isemail/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4721,29 +4699,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/joi": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
-      "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dependencies": {
-        "hoek": "5.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
-    "node_modules/joi/node_modules/hoek": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
-      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "engines": {
-        "node": ">=8.9.0"
       }
     },
     "node_modules/jsonfile": {
@@ -4949,11 +4904,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "node_modules/nan": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
-      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ=="
-    },
     "node_modules/nbb": {
       "version": "0.7.135",
       "resolved": "https://registry.npmjs.org/nbb/-/nbb-0.7.135.tgz",
@@ -4987,16 +4937,6 @@
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/node-expat": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.4.1.tgz",
-      "integrity": "sha512-uWgvQLgo883NKIL+66oJsK9ysKK3ej0YjVCPBZzO/7wMAuH68/Yb7+JwPWNaVq0yPaxrb48AoEXfYEc8gsmFbg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.19.0"
       }
     },
     "node_modules/node-fetch": {
@@ -5965,21 +5905,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/topo": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
-      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
-      "deprecated": "This module has moved and is now available at @hapi/topo. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "dependencies": {
-        "hoek": "6.x.x"
-      }
-    },
-    "node_modules/topo/node_modules/hoek": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
-      "deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues."
-    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -6336,19 +6261,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xml2json": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/xml2json/-/xml2json-0.12.0.tgz",
-      "integrity": "sha512-EPJHRWJnJUYbJlzR4pBhZODwWdi2IaYGtDdteJi0JpZ4OD31IplWALuit8r73dJuM4iHZdDVKY1tLqY2UICejg==",
-      "dependencies": {
-        "hoek": "^4.2.1",
-        "joi": "^13.1.2",
-        "node-expat": "^2.3.18"
-      },
-      "bin": {
-        "xml2json": "bin/xml2json"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "axios-retry": "^3.9.1",
     "debug": "^4.4.0",
     "dotenv": "^16.0.3",
+    "fast-xml-parser": "^4.5.3",
     "fs-extra": "^11.0.0",
-    "nbb": "^0.7.132",
-    "xml2json": "^0.12.0"
+    "nbb": "^0.7.132"
   },
   "devDependencies": {
     "shadow-cljs": "2.20.2"


### PR DESCRIPTION
xml2json requires building a native module for the XML parser, whereas fast-xml-parser does not.

A major difference between xml2json and newer parsing libraries like fast-xml-parser is how they treat attributes on XML nodes. xml2json doesn't differentiate attributes from child node names in the resulting Object. Newer libraries often use a prefix (`$_`) or special key (`$`) to distinguish attributes from child nodes. By setting fast-xml-parser's ignoreAttributes and attributeNamePrefix options, attributes should be handled identically.

Also, this sets textNodeName to maintain the usage of "$t" as the key for text values.

With these options set, the only remaining difference I could find when parsing before and after this change is how empty nodes (`<mynode/>`) are handled. xml2json parses that as an object (`{:mynode {}}`), while fast-xml-parser uses an empty string (`{:mynode ""}`). Regarding the Artifactory API, the only place I've observed this difference is in the <format> node of the response (specifically, <rpm:conflicts/> and <rpm:obsoletes/>).